### PR TITLE
Rename app from promptemplate-app to llm-translate-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# promptemplate-app
+# llm-translate-app
 
 An Electron application with React and TypeScript
 

--- a/dev-app-update.yml
+++ b/dev-app-update.yml
@@ -1,3 +1,3 @@
 provider: generic
 url: https://example.com/auto-updates
-updaterCacheDirName: promptemplate-app-updater
+updaterCacheDirName: llm-translate-app-updater

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,5 +1,5 @@
 appId: com.electron.app
-productName: promptemplate-app
+productName: llm-translate-app
 directories:
   buildResources: build
 files:
@@ -12,7 +12,7 @@ files:
 asarUnpack:
   - resources/**
 win:
-  executableName: promptemplate-app
+  executableName: llm-translate-app
 nsis:
   artifactName: ${name}-${version}-setup.${ext}
   shortcutName: ${productName}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "promptemplate-app",
+  "name": "llm-translate-app",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "promptemplate-app",
+      "name": "llm-translate-app",
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "promptemplate-app",
+  "name": "llm-translate-app",
   "version": "1.0.0",
   "description": "An Electron application with React and TypeScript",
   "main": "./out/main/index.js",


### PR DESCRIPTION
Update all references to the application name from promptemplate-app to llm-translate-app throughout the project files.